### PR TITLE
Add root route handler returning 200 OK to improve health checks

### DIFF
--- a/src/api/src/index.js
+++ b/src/api/src/index.js
@@ -26,6 +26,11 @@ const PORT = process.env.PORT || 3000;
 app.use(express.json());
 app.use(pinoHttp({ logger }));
 
+// Root handler to return 200 OK for default path and LB/health probes
+app.get('/', (req, res) => {
+  res.status(200).send('OK');
+});
+
 // Health check endpoints
 app.get('/health', async (req, res) => {
   const redisHealthy = await redisClient.healthCheck();


### PR DESCRIPTION
Pods can be Ready while external checks or manual browsing to the service root (/) appear "not running" because the app did not define a handler for /. Many probes and quick checks hit /. This PR adds a root GET / handler returning 200 OK, making default path and LB/health probes succeed without depending on Redis or specific API paths.

Change summary:
- Add app.get('/') => 200 OK in src/api/src/index.js

No functional API change; improves operability and health verification.